### PR TITLE
Add Post model and update CatProfile with user and posts

### DIFF
--- a/Controllers/CatProfilesController.cs
+++ b/Controllers/CatProfilesController.cs
@@ -1,11 +1,13 @@
+using System.Security.Claims;
 using CatBook.API.Data;
 using CatBook.API.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace CatBook.API.Controllers;
 
-
+[Authorize]
 [ApiController]
 [Route("api/[controller]")]
 public class CatProfilesController : ControllerBase
@@ -16,5 +18,69 @@ public class CatProfilesController : ControllerBase
     {
         _context = context;
     }
+
+    [HttpGet("me")]
+    public async Task<ActionResult<CatProfile>> GetMyProfile()
+    {
+        var googleId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (googleId == null) return Unauthorized();
+        
+        var user = await _context.Users.Include(u => u.Profile).FirstOrDefaultAsync(u => u.GoogleId == googleId);
+        if(user == null) return NotFound();
+        return Ok(user.Profile);
+    }
+
+
+    [HttpPost]
+    public async Task<ActionResult<CatProfile>> CreateProfile([FromBody] CatProfile profile)
+    {
+        var googleId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (googleId == null) return Unauthorized();
+        
+        var user = await _context.Users.Include(u => u.Profile).FirstOrDefaultAsync(u => u.GoogleId == googleId);
+        if(user == null) return NotFound();
+        if(user.Profile != null) return BadRequest("User already has a Cat profile");
+        
+        user.Profile = profile;
+        await _context.SaveChangesAsync();
+        return Ok(profile);
+    }
+    
+    [HttpPatch]
+    public async Task<ActionResult<CatProfile>> PatchProfile([FromBody] CatProfile updated)
+    {
+        var googleId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (googleId == null) return Unauthorized();
+        
+        var user = await _context.Users.Include(u => u.Profile).FirstOrDefaultAsync(u => u.GoogleId == googleId);
+        if(user == null) return NotFound();
+        
+        user.Profile.CatName = updated.CatName ?? user.Profile.CatName;
+        user.Profile.Age = updated.Age ?? user.Profile.Age;
+        user.Profile.Breed = updated.Breed ?? user.Profile.Breed;
+        user.Profile.Bio = updated.Bio ?? user.Profile.Bio;
+        
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+    
+    
+    [HttpDelete]
+    public async Task<ActionResult<CatProfile>> DeleteProfile()
+    {
+        var googleId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (googleId == null) return Unauthorized();
+        
+        var user = await _context.Users.Include(u => u.Profile).FirstOrDefaultAsync(u => u.GoogleId == googleId);
+        if(user == null) return NotFound();
+        
+        _context.CatProfiles.Remove(user.Profile);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
     
 }
+
+
+
+    

--- a/Controllers/PostsController.cs
+++ b/Controllers/PostsController.cs
@@ -1,0 +1,22 @@
+using System.Security.Claims;
+using CatBook.API.Data;
+using CatBook.API.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+
+namespace CatBook.API.Controllers;
+
+
+[ApiController]
+[Route("api/[controller]")]
+public class PostsController : ControllerBase
+{
+    private readonly CatBookContext _context;
+    
+    public PostsController(CatBookContext context)
+    {
+        _context = context;
+    }
+}

--- a/Data/CatBookContext.cs
+++ b/Data/CatBookContext.cs
@@ -10,7 +10,7 @@ public class CatBookContext : DbContext
     {
     }
     public DbSet<CatProfile> CatProfiles { get; set; }
-    
     public DbSet<User> Users { get; set; }
     
+    public DbSet<Post> Posts { get; set; }
 }

--- a/Migrations/20250628082449_AddPostsHandling.Designer.cs
+++ b/Migrations/20250628082449_AddPostsHandling.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CatBook.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CatBook.API.Migrations
 {
     [DbContext(typeof(CatBookContext))]
-    partial class CatBookContextModelSnapshot : ModelSnapshot
+    [Migration("20250628082449_AddPostsHandling")]
+    partial class AddPostsHandling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250628082449_AddPostsHandling.cs
+++ b/Migrations/20250628082449_AddPostsHandling.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CatBook.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPostsHandling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_CatProfiles_ProfileId",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_ProfileId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ProfileId",
+                table: "Users");
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "CatProfiles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "Posts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ImageUrl = table.Column<string>(type: "text", nullable: false),
+                    Caption = table.Column<string>(type: "text", nullable: false),
+                    PostedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CatProfileId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Posts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Posts_CatProfiles_CatProfileId",
+                        column: x => x.CatProfileId,
+                        principalTable: "CatProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CatProfiles_UserId",
+                table: "CatProfiles",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Posts_CatProfileId",
+                table: "Posts",
+                column: "CatProfileId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CatProfiles_Users_UserId",
+                table: "CatProfiles",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CatProfiles_Users_UserId",
+                table: "CatProfiles");
+
+            migrationBuilder.DropTable(
+                name: "Posts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CatProfiles_UserId",
+                table: "CatProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "CatProfiles");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProfileId",
+                table: "Users",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ProfileId",
+                table: "Users",
+                column: "ProfileId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_CatProfiles_ProfileId",
+                table: "Users",
+                column: "ProfileId",
+                principalTable: "CatProfiles",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Models/CatProfile.cs
+++ b/Models/CatProfile.cs
@@ -5,12 +5,20 @@ namespace CatBook.API.Models;
 public class CatProfile
 {
     public int  Id { get; set; }
+    
+    //content
     [Required]
     public string CatName { get; set; }
     [Required]
     public string Breed { get; set; }
     [Required]
-    public int Age { get; set; }
+    public int? Age { get; set; }
     [Required]
     public string Bio { get; set; }
+    
+    public List<Post> Posts { get; set; } 
+    
+    //foreign Key
+    public int UserId { get; set; }
+    public User User { get; set; }
 }

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CatBook.API.Models;
+
+public class Post
+{
+    public int Id { get; set; }
+    [Required]
+    public string ImageUrl { get; set; }
+    [Required]
+    public string Caption { get; set; }
+    [Required]
+    public DateTime PostedAt { get; set; } = DateTime.UtcNow;
+    
+    //foreign Key
+    public int CatProfileId { get; set; }
+    public CatProfile CatProfile { get; set; }
+}

--- a/Services/TokenService.cs
+++ b/Services/TokenService.cs
@@ -1,0 +1,11 @@
+using CatBook.API.Models;
+
+namespace CatBook.API.Services;
+
+public class TokenService
+{
+    public static string GenerateAccessToken(User user)
+    {
+        return "";
+    }
+}


### PR DESCRIPTION
Introduces the Post entity and its relationships, updates CatProfile to reference User and include posts, and adds PostsController. Database context and migrations are updated to support the new Post model and CatProfile-User relationship. CatProfilesController now supports authenticated CRUD operations for profiles. Adds a stub TokenService for future authentication handling.