### PR TITLE
Add Comments and Likes fields to Posts table

### DIFF
--- a/Migrations/20250629192356_PostUpdate.Designer.cs
+++ b/Migrations/20250629192356_PostUpdate.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using CatBook.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CatBook.API.Migrations
 {
     [DbContext(typeof(CatBookContext))]
-    partial class CatBookContextModelSnapshot : ModelSnapshot
+    [Migration("20250629192356_PostUpdate")]
+    partial class PostUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250629192356_PostUpdate.cs
+++ b/Migrations/20250629192356_PostUpdate.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CatBook.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class PostUpdate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Comments",
+                table: "Posts",
+                type: "text[]",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Likes",
+                table: "Posts",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Comments",
+                table: "Posts");
+
+            migrationBuilder.DropColumn(
+                name: "Likes",
+                table: "Posts");
+        }
+    }
+}


### PR DESCRIPTION
Introduced a migration that adds nullable 'Comments' (text array) and 'Likes' (integer) columns to the Posts table. Updated the model snapshot to reflect these schema changes.