### PR TITLE
Return 401 on authentication redirect

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,12 @@ builder.Services.AddAuthentication("CookieAuth")
         options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
         options.LoginPath = "/auth/google";
         options.ExpireTimeSpan = TimeSpan.FromDays(15);
+        
+        options.Events.OnRedirectToLogin = context =>
+        {
+            context.Response.StatusCode = 401;
+            return Task.CompletedTask;
+        };
     });
 
 builder.Services.AddAuthorization(options =>


### PR DESCRIPTION
Added an event handler to set the response status code to 401 instead of redirecting to the login page when authentication is required. This improves API usability by providing a proper unauthorized response.